### PR TITLE
[ocaml]: a wrapped library with masking

### DIFF
--- a/examples/prelude/ocaml/wrap/BUCK
+++ b/examples/prelude/ocaml/wrap/BUCK
@@ -1,8 +1,10 @@
 # @lint-ignore-every BUCKFORMAT
 
+load("//test_utils.bzl", "assert_output")
+
 # buildifier: disable=no-effect
 ocaml_library(
-    name = "_mylib",
+    name = "mylib__",
     compiler_flags = [
         "-no-alias-deps",
         "-w", "-49",
@@ -11,12 +13,13 @@ ocaml_library(
         "mylib.mli",
         "mylib.ml",
     ],
-    visibility = [ "PUBLIC" ],
+    visibility = [ ':mylib' ],
 ) if not host_info().os.is_windows else None
 
 export_file(
     name= "mylib.mli",
-    src = "mylib.mli"
+    src = "mylib.mli",
+    visibility = [ ':mylib.cmxa' ],
 )
 
 # buildifier: disable=no-effect
@@ -35,14 +38,21 @@ ocaml_library(
         "mylib__A.ml",
         "mylib__B.ml",
     ],
-    deps = [ ":_mylib" ],
-    visibility = [ "PUBLIC" ],
+    deps = [ ":mylib__" ],
+    visibility = [ 'PUBLIC' ],
 ) if not host_info().os.is_windows else None
 
 # buildifier: disable=no-effect
 ocaml_binary(
-    name = "test-mylib",
+    name = "test-Mylib",
     srcs = [ "test_Mylib.ml" ] ,
     deps = [ ":mylib" ],
-    visibility = [ "PUBLIC" ],
+    visibility = [ 'PUBLIC' ],
+) if not host_info().os.is_windows else None
+
+# buildifier: disable=no-effect
+assert_output(
+    name = "test-Mylib-check",
+    command = "$(exe_target :test-Mylib)",
+    output = "Hello world!",
 ) if not host_info().os.is_windows else None

--- a/examples/prelude/ocaml/wrap/with-masking/BUCK
+++ b/examples/prelude/ocaml/wrap/with-masking/BUCK
@@ -1,0 +1,68 @@
+# @lint-ignore-every BUCKFORMAT
+
+load("//test_utils.bzl", "assert_output")
+
+# buildifier: disable=no-effect
+export_file(
+    name = "al__.mli",
+    visibility = [
+        ":al__",
+        ":al__imp"
+    ],
+
+) if not host_info().os.is_windows else None
+
+# buildifier: disable=no-effect
+ocaml_library(
+    name = "al__",
+    compiler_flags = [ "-no-alias-deps" ],
+    srcs = [
+        ":al__.mli",
+        "al__.ml",
+    ],
+    visibility = [ ":al__imp" ],
+
+) if not host_info().os.is_windows else None
+
+# buildifier: disable=no-effect
+ocaml_library(
+    name = "al__imp",
+    compiler_flags = [
+        "-open", "Al__"
+    ],
+    ocamldep_flags = [
+        "-open", "Al__",
+        "-map", "$(location :al__.mli)"
+    ],
+    srcs = glob( [ "al__*.ml*" ], exclude = [ "al__.ml*" ] ),
+    deps = [ ":al__" ],
+    visibility = [ ":al" ],
+
+) if not host_info().os.is_windows else None
+
+# buildifier: disable=no-effect
+ocaml_library(
+    name = "al",
+    compiler_flags = [ "-open", "Al__" ],
+    srcs = glob( [ "al.ml*" ] ),
+    deps = [ ":al__imp" ],
+    visibility = [ "PUBLIC" ],
+
+) if not host_info().os.is_windows else None
+
+# buildifier: disable=no-effect
+ocaml_binary(
+    name = "test-Al",
+    srcs = [ "test_Al.ml" ],
+    deps = [ ":al" ],
+    visibility = [ "PUBLIC" ],
+
+) if not host_info().os.is_windows else None
+
+# buildifier: disable=no-effect
+assert_output(
+    name = "test-Al-check",
+    command = "$(exe_target :test-Al)",
+    output = "Hello world!",
+
+) if not host_info().os.is_windows else None

--- a/examples/prelude/ocaml/wrap/with-masking/al.ml
+++ b/examples/prelude/ocaml/wrap/with-masking/al.ml
@@ -1,0 +1,5 @@
+let print_hello () = A.print_hello ()
+
+module B: module type of B = struct
+  include B
+ end

--- a/examples/prelude/ocaml/wrap/with-masking/al.mli
+++ b/examples/prelude/ocaml/wrap/with-masking/al.mli
@@ -1,0 +1,2 @@
+val print_hello: unit -> unit
+module B: sig val print_hello: unit -> unit end

--- a/examples/prelude/ocaml/wrap/with-masking/al__.ml
+++ b/examples/prelude/ocaml/wrap/with-masking/al__.ml
@@ -1,0 +1,4 @@
+module A = Al__A
+module B = Al__B
+module C = Al__C
+module Al__ = struct end

--- a/examples/prelude/ocaml/wrap/with-masking/al__.mli
+++ b/examples/prelude/ocaml/wrap/with-masking/al__.mli
@@ -1,0 +1,4 @@
+module A = Al__A
+module B = Al__B
+module C = Al__C
+module Al__ : sig end

--- a/examples/prelude/ocaml/wrap/with-masking/al__A.ml
+++ b/examples/prelude/ocaml/wrap/with-masking/al__A.ml
@@ -7,4 +7,4 @@
  * of this source tree.
  *)
 
-let print_hello () = Printf.printf "Hello world!\n"
+let print_hello () = B.print_hello ()

--- a/examples/prelude/ocaml/wrap/with-masking/al__B.ml
+++ b/examples/prelude/ocaml/wrap/with-masking/al__B.ml
@@ -7,4 +7,4 @@
  * of this source tree.
  *)
 
-let print_hello () = Printf.printf "Hello world!\n"
+let print_hello () = C.print_hello ()

--- a/examples/prelude/ocaml/wrap/with-masking/al__C.ml
+++ b/examples/prelude/ocaml/wrap/with-masking/al__C.ml
@@ -1,0 +1,1 @@
+let print_hello() = Printf.printf "Hello world!\n"

--- a/examples/prelude/ocaml/wrap/with-masking/test_Al.ml
+++ b/examples/prelude/ocaml/wrap/with-masking/test_Al.ml
@@ -1,0 +1,21 @@
+let _: unit = Al.print_hello () (* ok *)
+let _: unit = Al.B.print_hello () (* ok *)
+
+(*
+let _: unit = Al__.A.print_hello () (* ok *)
+let _: unit = Al__.B.print_hello () (* ok *)
+let _: unit = Al__.C.print_hello () (* ok *)
+*)
+
+(*
+let _: unit = Al__A.print_hello () (* ok *)
+let _: unit = Al__B.print_hello () (* ok *)
+let _: unit = Al__C.print_hello () (* ok *)
+*)
+
+(*
+let _: unit = A.print_hello () (* Error: Unbound module A *)
+let _: unit = B.print_hello () (* Error: Unbound module B *)
+let _: unit = Al.A.print_hello () (* Error: Unbound module Al.A *)
+let _: unit = Al.C.print_hello () (* Error: Unbound module Al.C *)
+*)

--- a/prelude/remote_file.bzl
+++ b/prelude/remote_file.bzl
@@ -16,9 +16,14 @@ def _from_mvn_url(url: str.type) -> str.type:
     """
 
     count = url.count(":")
+    mod = ""
 
     if count == 4:
         mvn, group, id, typ, version = url.split(":")
+        repo = _ROOT
+    elif count == 5:
+        mvn, group, id, typ, mod, version = url.split(":")
+        mod = "-" + mod
         repo = _ROOT
     elif count == 6:
         mvn, repo_protocol, repo_host, group, id, typ, version = url.split(":")
@@ -35,12 +40,13 @@ def _from_mvn_url(url: str.type) -> str.type:
     else:
         ext = "." + typ
 
-    return "{repo}/{group}/{id}/{version}/{id}-{version}{ext}".format(
+    return "{repo}/{group}/{id}/{version}/{id}-{version}{mod}{ext}".format(
         repo = repo,
         group = group,
         id = id,
         version = version,
         ext = ext,
+        mod = mod,
     )
 
 # Implementation of the `remote_file` build rule.

--- a/starlark-rust/starlark/src/debug/adapter/tests.rs
+++ b/starlark-rust/starlark/src/debug/adapter/tests.rs
@@ -42,6 +42,7 @@ mod t {
     use crate::syntax::AstModule;
     use crate::syntax::Dialect;
     use crate::values::OwnedFrozenValue;
+    use crate::wasm::is_wasm;
 
     #[derive(Debug)]
     struct Client {
@@ -157,6 +158,11 @@ mod t {
 
     #[test]
     fn test_breakpoint() -> anyhow::Result<()> {
+        if is_wasm() {
+            // `thread::scope` doesn't work in wasm.
+            return Ok(());
+        }
+
         let controller = BreakpointController::new();
         let (adapter, eval_hook) = prepare_dap_adapter(controller.get_client());
         let file_contents = "
@@ -184,6 +190,10 @@ print(x)
 
     #[test]
     fn test_breakpoint_with_failing_condition() -> anyhow::Result<()> {
+        if is_wasm() {
+            return Ok(());
+        }
+
         let controller = BreakpointController::new();
         let (adapter, eval_hook) = prepare_dap_adapter(controller.get_client());
         let file_contents = "
@@ -204,6 +214,10 @@ print(x)
 
     #[test]
     fn test_breakpoint_with_passing_condition() -> anyhow::Result<()> {
+        if is_wasm() {
+            return Ok(());
+        }
+
         let controller = BreakpointController::new();
         let (adapter, eval_hook) = prepare_dap_adapter(controller.get_client());
         let file_contents = "
@@ -230,6 +244,10 @@ print(x)
 
     #[test]
     fn test_step_over() -> anyhow::Result<()> {
+        if is_wasm() {
+            return Ok(());
+        }
+
         let controller = BreakpointController::new();
         let (adapter, eval_hook) = prepare_dap_adapter(controller.get_client());
         let file_contents = "
@@ -273,6 +291,10 @@ print(x)
 
     #[test]
     fn test_step_into() -> anyhow::Result<()> {
+        if is_wasm() {
+            return Ok(());
+        }
+
         let controller = BreakpointController::new();
         let (adapter, eval_hook) = prepare_dap_adapter(controller.get_client());
         let file_contents = "
@@ -333,6 +355,10 @@ print(x)
 
     #[test]
     fn test_step_out() -> anyhow::Result<()> {
+        if is_wasm() {
+            return Ok(());
+        }
+
         let controller = BreakpointController::new();
         let (adapter, eval_hook) = prepare_dap_adapter(controller.get_client());
         let file_contents = "

--- a/starlark-rust/starlark/src/debug/evaluate.rs
+++ b/starlark-rust/starlark/src/debug/evaluate.rs
@@ -117,6 +117,7 @@ mod tests {
     use crate::assert;
     use crate::environment::GlobalsBuilder;
     use crate::syntax::Dialect;
+    use crate::wasm::is_wasm;
 
     #[starlark_module]
     fn debugger(builder: &mut GlobalsBuilder) {
@@ -131,6 +132,10 @@ mod tests {
 
     #[test]
     fn test_debug_evaluate() {
+        if is_wasm() {
+            return;
+        }
+
         let mut a = assert::Assert::new();
         a.globals_add(debugger);
         let check = r#"

--- a/starlark-rust/starlark/src/lib.rs
+++ b/starlark-rust/starlark/src/lib.rs
@@ -408,6 +408,7 @@ mod hint;
 mod stdlib;
 pub mod syntax;
 pub mod values;
+pub(crate) mod wasm;
 
 pub mod coerce;
 #[cfg(test)]

--- a/starlark-rust/starlark/src/values/layout/heap/arena.rs
+++ b/starlark-rust/starlark/src/values/layout/heap/arena.rs
@@ -172,11 +172,11 @@ impl<A: ArenaAllocator> Arena<A> {
         &'v mut [MaybeUninit<T::ExtraElem>],
     ) {
         assert!(
-            mem::align_of::<T>() <= mem::align_of::<AValueHeader>(),
+            mem::align_of::<T>() <= AValueHeader::ALIGN,
             "Unexpected alignment in Starlark arena. Type {} has alignment {}, expected <= {}",
             std::any::type_name::<T>(),
             mem::align_of::<T>(),
-            mem::align_of::<AValueHeader>()
+            AValueHeader::ALIGN,
         );
 
         let size = T::memory_size_for_extra_len(extra_len).add_header();

--- a/starlark-rust/starlark/src/wasm.rs
+++ b/starlark-rust/starlark/src/wasm.rs
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 The Starlark in Rust Authors.
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#[cfg(test)]
+pub(crate) fn is_wasm() -> bool {
+    cfg!(target_arch = "wasm32")
+}


### PR DESCRIPTION
A wrapped library has top-level module `Al` with signature
```ocaml
  (* al.mli *)

  val print_hello: unit -> unit
  modue B : sig val print_hello: unit -> unit end
```
The library contains implmentation modules`al__B.ml` and `al__C.ml`.

`al__B.ml` has contents
```ocaml
  (* al__B.ml*)

  let print_hello () = C.print_hello ()
```
referencing `al__C.ml`
```ocaml
  (* al__C.ml*)

  let print_hello () = Printf.printf "Hello world!\n"
```
and the implementation of `Al.ml` itself is
```ocaml
(* al.ml *)

let print_hello () = B.print_hello ()

module B: module type of B = struct
  include B
 end
```
 A test program that exercises `Al`:
```ocaml
  (* test_Al.ml *)

  let _: unit = Al.print_hello () (* calls B.print_hello () *)
  let _: unit = Al.B.print_hello () (* calls C.print_hello () *)

  (* let _: unit = B.print_hello () *) (* Error: Unbound module B *)
  (* let _: unit = Al.C.print_hello () *) (* Error: Unbound module Al.C *)
```
